### PR TITLE
made windowed mode resolution-dependent

### DIFF
--- a/classes.lisp
+++ b/classes.lisp
@@ -643,16 +643,16 @@ vector at that position"))
 (defclass game ()
   (;; Important dimensions about the display window and game world size
    (%window-width :initarg :window-width
-                  :initform 1024
+                  :initform +game-width+
                   :accessor window-width)
    (%window-height :initarg :window-height
-                   :initform 768
+                   :initform +game-height+
                    :accessor window-height)
    (%game-width :initarg :game-width
-                :initform 100
+                :initform +game-width+
                 :accessor game-width)
    (%game-height :initarg :game-height
-                 :initform 100
+                 :initform +game-height+
                  :accessor game-height)
 
    ;; Make the universe object which is the root of the scene tree.

--- a/constants.lisp
+++ b/constants.lisp
@@ -58,3 +58,5 @@ writing this macro and then thrown into hell for naming it thusly."
 (defconstant +game-width+ 160)
 (defconstant +game-height+ 128)
 
+(defparameter *windowed-modes* '((1280 . 1024) (640 . 512)))
+

--- a/constants.lisp
+++ b/constants.lisp
@@ -51,3 +51,10 @@ writing this macro and then thrown into hell for naming it thusly."
       ;; call function call that'll do the work with the evaluated
       ;; expression.
       `(%? ,expr)))
+
+;; The game size has the same aspect ratio as the window resolutions I
+;; am willing to allow. The levels are designed to 160 witdh by 128
+;; height, so don't change it.
+(defconstant +game-width+ 160)
+(defconstant +game-height+ 128)
+

--- a/game.lisp
+++ b/game.lisp
@@ -16,8 +16,8 @@
 
 #+option-9-debug (declaim (optimize (safety 3) (space 0) (speed 0) (debug 3)))
 
-(defun make-game (&key (window-width 1280) (window-height 1024)
-                    (game-width 160) (game-height 128))
+(defun make-game (&key (window-width +game-width+) (window-height +game-height+)
+                    (game-width +game-width+) (game-height +game-height+))
   (let ((game (make-instance 'game
                              :scene-man (make-instance 'scene-manager)
                              :window-width window-width
@@ -72,10 +72,10 @@
       (setf (paused g) t)))
 
 (defmacro with-game-init ((filename &key
-                                    (window-width 1280)
-                                    (window-height 1024)
-                                    (game-width 160)
-                                    (game-height 128))
+                                    (window-width +game-width+)
+                                    (window-height +game-height+)
+                                    (game-width +game-width+)
+                                    (game-height +game-height+))
                           &body body)
   ;; The let* is important to bind *id* before MAKE-GAME is called.
   `(let* ((*assets* (load-dat-file ,filename))

--- a/option-9.lisp
+++ b/option-9.lisp
@@ -108,14 +108,11 @@
   (format t "Written by Peter Keller <psilord@cs.wisc.edu>~%")
   (format t "Ship Designs by Stephanie Keller <aset_isis@hotmail.com>~%")
 
-  (with-game-init ("option-9.dat" :window-width 1280 :window-height 1024
-                                  ;; The game size has the same aspect ratio
-                                  ;; as the window resolutions I am willing
-                                  ;; to allow. The levels are designed to
-                                  ;; 160 witdh by 128 height, so don't change
-                                  ;; it.
-                                  :game-width 160 :game-height 128)
-    (sdl2:with-init (:video :gamecontroller :events :noparachute)
+  (with-game-init ("option-9.dat")
+    (sdl2:with-init (:video :gamecontroller :noparachute)
+
+      ;; @TODO Calculate the window size
+
       ;; for post processing smoothing of the lines and whantot.
       ;; set before I make the window and OpenGL context.
       ;;(sdl2:gl-set-attr :multisamplebuffers 1)

--- a/option-9.lisp
+++ b/option-9.lisp
@@ -102,6 +102,21 @@
 ;;                   controller-name
 ;;                   has-haptic)))))))
 
+(defun set-initial-game-window-size (game)
+  (labels ((set-window-size (max-width max-height resolutions)
+             (let ((width (caar resolutions))
+                   (height (cdar resolutions)))
+               (when resolutions
+                 (if (and (< width max-width)
+                          (< height max-height))
+                     (setf (window-width game) width
+                           (window-height game) height)
+                     (set-window-size max-width max-height (cdr resolutions)))))))
+    (multiple-value-bind (format
+                          width
+                          height) (sdl2:get-current-display-mode 0)
+      (set-window-size width height *windowed-modes*))))
+
 (defun game-main ()
   (format t "Welcome to Option 9, Version 0.9!~%")
   (format t "A space shoot'em up game written in CLOS.~%")
@@ -110,9 +125,7 @@
 
   (with-game-init ("option-9.dat")
     (sdl2:with-init (:video :gamecontroller :noparachute)
-
-      ;; @TODO Calculate the window size
-
+      (set-initial-game-window-size *game*)
       ;; for post processing smoothing of the lines and whantot.
       ;; set before I make the window and OpenGL context.
       ;;(sdl2:gl-set-attr :multisamplebuffers 1)


### PR DESCRIPTION
The default windowed mode was too large for my laptop display, so I first check the desktop resolution before picking a predefined windowed size.
